### PR TITLE
Fix trivial term for KEEP_M case, and lambda=1 contribution to c_m.

### DIFF
--- a/chsh_local.py
+++ b/chsh_local.py
@@ -92,8 +92,8 @@ def compute_entropy(SDP):
 
         SDP -- sdp relaxation object
     """
-    ck = 0.0        # kth coefficient
-    ent = 0.0        # lower bound on H(A|X=0,E)
+    ck = 0.0                             # kth coefficient
+    ent = -1.0 / (len(T)**2 * log(2))    # lower bound on H(A|X=0,E)
 
     # We can also decide whether to perform the final optimization in the sequence
     # or bound it trivially. Best to keep it unless running into numerical problems
@@ -101,6 +101,7 @@ def compute_entropy(SDP):
         num_opt = len(T)
     else:
         num_opt = len(T) - 1
+        ent += W[num_opt]/(T[num_opt] * log(2))
 
     for k in range(num_opt):
         ck = W[k]/(T[k] * log(2))


### PR DESCRIPTION
Hi Peter!

I noticed that there is a minor offset error in your KEEP_M=0 case for your DI rates (missing the last contribution from the constant terms, because it's skipped).

Also, there was missing term for lambda=1 from the c_m term in your optimization.

In practice, this only amounts to a very small correction; and I'm not really an expert on this at all, so please double check! I was just wondering why your script was giving different answers to one Mateus had written, using the SDP description in your article...

Anyway, I've pull-requested what I think needs changing.

- Andy